### PR TITLE
Added Runtime Parameter for Activity Group File

### DIFF
--- a/src/main/kotlin/de/uniwuerzburg/omod/Main.kt
+++ b/src/main/kotlin/de/uniwuerzburg/omod/Main.kt
@@ -119,6 +119,10 @@ class Run : CliktCommand() {
         help="Path to file that describes the socio-demographic makeup of the population. " +
              "Must be formatted like omod/src/main/resources/Population.json."
     ).file(mustExist = true, mustBeReadable = true)
+    private val activity_group_file by option(
+        help="Path to json file that describes the activity chains and their dwell-time distribution for the chosen location. " +
+        "Must be formatted like omod/src/main/resources/ActivityGroup.json"
+    ).file(mustExist = true, mustBeReadable = true)
     private val n_worker by option(
         help="Number of parallel coroutines that can be executed at the same time. " +
              "Default: Number of CPU-Cores available."
@@ -154,6 +158,7 @@ class Run : CliktCommand() {
             populateBufferArea = populate_buffer_area,
             distanceCacheSize = distance_matrix_cache_size,
             populationFile = population_file,
+            activityGroupFile = activity_group_file,
             nWorker = n_worker,
             gtfsFile = gtfs_file
         )

--- a/src/main/kotlin/de/uniwuerzburg/omod/Main.kt
+++ b/src/main/kotlin/de/uniwuerzburg/omod/Main.kt
@@ -120,7 +120,7 @@ class Run : CliktCommand() {
              "Must be formatted like omod/src/main/resources/Population.json."
     ).file(mustExist = true, mustBeReadable = true)
     private val activity_group_file by option(
-        help="Path to json file that describes the activity chains and their dwell-time distribution for the chosen location. " +
+        help="Path to file that describes the activity chains for each population group and the dwell-time distribution for the each chain. " +
         "Must be formatted like omod/src/main/resources/ActivityGroup.json"
     ).file(mustExist = true, mustBeReadable = true)
     private val n_worker by option(

--- a/src/main/kotlin/de/uniwuerzburg/omod/core/Omod.kt
+++ b/src/main/kotlin/de/uniwuerzburg/omod/core/Omod.kt
@@ -51,6 +51,7 @@ import kotlin.time.TimeSource
  * @param populateBufferArea Option to populate the buffer area with agents
  * @param distanceCacheSize Maximum size of the routing matrix cache
  * @param populationFile File that defines the distribution of socio-demographic features for the agent population
+ * @param activityGroupFile File that defines the activity chains and their dwell times for the chosen location
  * @param nWorker Number of parallel coroutines that can be executed at the same time.
  * NULL = Number of CPU-Cores available.
  * @param gtfsFile GTFS location (Directory or .zip file)
@@ -69,6 +70,7 @@ class Omod(
     private val populateBufferArea: Boolean = true,
     val distanceCacheSize: Long = 400e6.toLong(),
     populationFile: File? = null,
+    activityGroupFile: File? = null,
     nWorker: Int? = null,
     private val gtfsFile: File? = null,
     carOwnershipOption: CarOwnershipOption = CarOwnershipOption.FIX
@@ -103,7 +105,11 @@ class Omod(
         }
 
         // Load activity chain data
-        val activityGroups: List<ActivityGroup> = readJsonFromResource("ActivityGroups.json")
+        val activityGroups: List<ActivityGroup> = if (activityGroupFile !=null){
+            readJson(activityGroupFile)
+        } else {
+            readJsonFromResource("ActivityGroupsKorea.json")
+        }
 
         // Load distance distributions
         val mutLocChoiceFuns: MutableMap<ActivityType, LocationChoiceDCWeightFun> =

--- a/src/main/kotlin/de/uniwuerzburg/omod/core/Omod.kt
+++ b/src/main/kotlin/de/uniwuerzburg/omod/core/Omod.kt
@@ -108,7 +108,7 @@ class Omod(
         val activityGroups: List<ActivityGroup> = if (activityGroupFile !=null){
             readJson(activityGroupFile)
         } else {
-            readJsonFromResource("ActivityGroupsKorea.json")
+            readJsonFromResource("ActivityGroups.json")
         }
 
         // Load distance distributions


### PR DESCRIPTION
This Pull Request adds a runtime parameter for the activityGroups file. The activityGroups file contains the distribution of activity chains for each subgroup of the population as well as the dwelltime distribution for each activity in a specific activity chain. 
The parameter allows a switching of different parametrizations of activity chains, which can be especially helpful when investigating different countries and travel patterns.