### PR TITLE
Fixed issue where a cast to Polygon fails due to the object being a MultiPolygon

### DIFF
--- a/src/main/kotlin/de/uniwuerzburg/omosim/io/osm/OSMProcessor.kt
+++ b/src/main/kotlin/de/uniwuerzburg/omosim/io/osm/OSMProcessor.kt
@@ -249,18 +249,19 @@ class OSMProcessor(idTrackerType: IdTrackerType,
             }
             mutInnerRings.removeAll(holes)
 
+            // Stamp holes into polygon
             val holesAsPolygon = holes.map { geometryFactory.createPolygon(it) }.toTypedArray()
             val hole = geometryFactory.createMultiPolygon(holesAsPolygon).union()
+            val punchedGeom = polygon.difference(hole)
 
-            val d = polygon.difference(hole)
-            if (d.geometryType.compareTo("Polygon")==0){
-                polygons.add ( d as Polygon )
-            }
-            else if(d.geometryType.compareTo("MultiPolygon")==0){
-                for (i in 0..<d.numGeometries){
-                    val de = d.getGeometryN(i)
-                    polygons.add(de as Polygon)
+            when (punchedGeom) {
+                is Polygon -> polygons.add ( punchedGeom )
+                is MultiPolygon -> {
+                    for (i in 0 until punchedGeom.numGeometries){
+                        polygons.add( punchedGeom.getGeometryN(i) as Polygon )
+                    }
                 }
+                else -> continue // Creating lines or points should be impossible
             }
         }
         val geometry = geometryFactory.createMultiPolygon(polygons.toTypedArray()).union()

--- a/src/main/kotlin/de/uniwuerzburg/omosim/io/osm/OSMProcessor.kt
+++ b/src/main/kotlin/de/uniwuerzburg/omosim/io/osm/OSMProcessor.kt
@@ -252,7 +252,16 @@ class OSMProcessor(idTrackerType: IdTrackerType,
             val holesAsPolygon = holes.map { geometryFactory.createPolygon(it) }.toTypedArray()
             val hole = geometryFactory.createMultiPolygon(holesAsPolygon).union()
 
-            polygons.add ( polygon.difference(hole) as Polygon )
+            val d = polygon.difference(hole)
+            if (d.geometryType.compareTo("Polygon")==0){
+                polygons.add ( d as Polygon )
+            }
+            else if(d.geometryType.compareTo("MultiPolygon")==0){
+                for (i in 0..<d.numGeometries){
+                    val de = d.getGeometryN(i)
+                    polygons.add(de as Polygon)
+                }
+            }
         }
         val geometry = geometryFactory.createMultiPolygon(polygons.toTypedArray()).union()
 


### PR DESCRIPTION
The `polygon.difference(hole)` function only returns a Geometry object, which is in most cases of type `Polygon` and the cast works as expected. In some cases the call can return a `MultiPolygon`. In this case, each individual `Polygon` has to be added individually to the polygon List (`polygons`)